### PR TITLE
Change to be the latest tracks instead of top tracks

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -6,7 +6,7 @@ function addLastFmWidgetToDiv(divSelector, username, apiKey) {
   container.style.paddingBottom = '32px';
 
   var title = document.createElement('div');
-  title.innerText = '🎵 Last.fm Weekly Top Tracks';
+  title.innerText = '🎵 Last.fm Recent tracks';
   title.style.fontWeight = 'bold';
   title.style.marginBottom = '8px';
   container.appendChild(title);
@@ -21,12 +21,12 @@ function addLastFmWidgetToDiv(divSelector, username, apiKey) {
   loading.innerText = 'Loading...';
   container.appendChild(loading);
 
-  fetch(`https://ws.audioscrobbler.com/2.0/?method=user.getweeklytrackchart&user=${encodeURIComponent(username)}&api_key=${encodeURIComponent(apiKey)}&format=json`)
+  fetch(`https://ws.audioscrobbler.com/2.0/?method=user.getRecentTracks&user=${encodeURIComponent(username)}&api_key=${encodeURIComponent(apiKey)}&format=json&limit=10`)
     .then(res => res.json())
     .then(data => {
       loading.remove();
-      if (data.weeklytrackchart && data.weeklytrackchart.track && data.weeklytrackchart.track.length > 0) {
-        data.weeklytrackchart.track.slice(0, 10).forEach(function(track) {
+      if (data.recenttracks && data.recenttracks.track && data.recenttracks.track.length > 0) {
+        data.recenttracks.track.forEach(function(track) {
           var li = document.createElement('li');
           li.style.marginBottom = '4px';
           var trackName = track.name || 'Unknown';


### PR DESCRIPTION
This pull request updates the Last.fm widget to display a user's recent tracks instead of their weekly top tracks. The changes update both the widget's title and the API call to fetch and display the most recent tracks.

I noticed my sleep playlist was dominating my weekly tracks which duh, so let's show different data. 